### PR TITLE
✨ Add processInstanceId to written metrics 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics_api_core#readme",
   "dependencies": {
-    "@process-engine/metrics_api_contracts": "^1.0.0",
+    "@process-engine/metrics_api_contracts": "feature~add_process_instance_id",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/process-engine/metrics_api_core#readme",
   "dependencies": {
-    "@process-engine/metrics_api_contracts": "feature~add_process_instance_id",
+    "@process-engine/metrics_api_contracts": "^2.0.0",
     "moment": "^2.24.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/metrics_api_core",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Contains all the core components for the metrics api. ",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "url": "git+https://github.com/process-engine/metrics_api_core.git"
   },
   "author": "5Minds IT-Solutions GmbH & Co. KG",
-  "contributors": [
-    "Sebastian Meier <sebastian.meier@5minds.de>",
-    "Christian Werner <christian.werner@5minds.de>"
+  "maintainers": [
+    "Alexander Kasten <alexander.kasten@5minds.de>",
+    "Christian Werner <christian.werner@5minds.de>",
+    "René Föhring <rene.foehring@5minds.de>",
+    "Steffen Knaup <steffen.knaup@5minds.de>"
   ],
   "license": "MIT",
   "bugs": {

--- a/src/metrics_api_service.ts
+++ b/src/metrics_api_service.ts
@@ -1,86 +1,125 @@
 import * as moment from 'moment';
 
+import {IIdentity} from '@essential-projects/iam_contracts';
 import {
-  IMetricsApi, IMetricsRepository, MetricMeasurementPoint, ProcessToken,
+  IMetricsApi, IMetricsRepository, Metric, MetricMeasurementPoint,
 } from '@process-engine/metrics_api_contracts';
 
 export class MetricsApiService implements IMetricsApi {
 
-  private readonly metricsRepository: IMetricsRepository;
+  private metricsRepository: IMetricsRepository;
 
   constructor(metricsRepository: IMetricsRepository) {
     this.metricsRepository = metricsRepository;
   }
 
-  public async writeOnProcessStarted(correlationId: string, processModelId: string, timestamp: moment.Moment): Promise<void> {
-    await this.metricsRepository.writeMetricForProcessModel(correlationId, processModelId, MetricMeasurementPoint.onProcessStart, timestamp);
+  public async readMetricsForProcessModel(identity: IIdentity, processModelId: string): Promise<Array<Metric>> {
+
+    return this
+      .metricsRepository
+      .readMetricsForProcessModel(processModelId);
   }
 
-  public async writeOnProcessFinished(correlationId: string, processModelId: string, timestamp: moment.Moment): Promise<void> {
-    await this.metricsRepository.writeMetricForProcessModel(correlationId, processModelId, MetricMeasurementPoint.onProcessFinish, timestamp);
+  public async writeOnProcessStarted(
+    correlationId: string,
+    processInstanceId: string,
+    processModelId: string,
+    timestamp: moment.Moment,
+  ): Promise<void> {
+
+    await this
+      .metricsRepository
+      .writeMetricForProcessInstance(correlationId, processInstanceId, processModelId, MetricMeasurementPoint.onProcessStart, timestamp);
   }
 
-  public async writeOnProcessError(correlationId: string, processModelId: string, error: Error, timestamp: moment.Moment): Promise<void> {
-    await this.metricsRepository.writeMetricForProcessModel(correlationId, processModelId, MetricMeasurementPoint.onProcessError, timestamp, error);
+  public async writeOnProcessFinished(
+    correlationId: string,
+    processInstanceId: string,
+    processModelId: string,
+    timestamp: moment.Moment,
+  ): Promise<void> {
+
+    await this
+      .metricsRepository
+      .writeMetricForProcessInstance(correlationId, processInstanceId, processModelId, MetricMeasurementPoint.onProcessFinish, timestamp);
+  }
+
+  public async writeOnProcessError(
+    correlationId: string,
+    processInstanceId: string,
+    processModelId: string,
+    error: Error,
+    timestamp: moment.Moment,
+  ): Promise<void> {
+
+    await this
+      .metricsRepository
+      .writeMetricForProcessInstance(correlationId, processInstanceId, processModelId, MetricMeasurementPoint.onProcessError, timestamp, error);
   }
 
   public async writeOnFlowNodeInstanceEnter(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
-    processToken: ProcessToken,
+    tokenPayload: any,
     timestamp: moment.Moment,
   ): Promise<void> {
 
-    await this.metricsRepository.writeMetricForFlowNode(
+    await this.metricsRepository.writeMetricForFlowNodeInstance(
       correlationId,
+      processInstanceId,
       processModelId,
       flowNodeInstanceId,
       flowNodeId,
       MetricMeasurementPoint.onFlowNodeEnter,
-      processToken,
+      tokenPayload,
       timestamp,
     );
   }
 
   public async writeOnFlowNodeInstanceExit(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
-    processToken: ProcessToken,
+    tokenPayload: any,
     timestamp: moment.Moment,
   ): Promise<void> {
 
-    await this.metricsRepository.writeMetricForFlowNode(
+    await this.metricsRepository.writeMetricForFlowNodeInstance(
       correlationId,
+      processInstanceId,
       processModelId,
       flowNodeInstanceId,
       flowNodeId,
       MetricMeasurementPoint.onFlowNodeExit,
-      processToken,
+      tokenPayload,
       timestamp,
     );
   }
 
   public async writeOnFlowNodeInstanceError(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
-    processToken: ProcessToken,
+    tokenPayload: any,
     error: Error,
     timestamp: moment.Moment,
   ): Promise<void> {
 
-    await this.metricsRepository.writeMetricForFlowNode(
+    await this.metricsRepository.writeMetricForFlowNodeInstance(
       correlationId,
+      processInstanceId,
       processModelId,
       flowNodeInstanceId,
       flowNodeId,
       MetricMeasurementPoint.onFlowNodeError,
-      processToken,
+      tokenPayload,
       timestamp,
       error,
     );
@@ -88,40 +127,44 @@ export class MetricsApiService implements IMetricsApi {
 
   public async writeOnFlowNodeInstanceSuspend(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
-    processToken: ProcessToken,
+    tokenPayload: any,
     timestamp: moment.Moment,
   ): Promise<void> {
 
-    await this.metricsRepository.writeMetricForFlowNode(
+    await this.metricsRepository.writeMetricForFlowNodeInstance(
       correlationId,
+      processInstanceId,
       processModelId,
       flowNodeInstanceId,
       flowNodeId,
       MetricMeasurementPoint.onFlowNodeSuspend,
-      processToken,
+      tokenPayload,
       timestamp,
     );
   }
 
   public async writeOnFlowNodeInstanceResume(
     correlationId: string,
+    processInstanceId: string,
     processModelId: string,
     flowNodeInstanceId: string,
     flowNodeId: string,
-    processToken: ProcessToken,
+    tokenPayload: any,
     timestamp: moment.Moment,
   ): Promise<void> {
 
-    await this.metricsRepository.writeMetricForFlowNode(
+    await this.metricsRepository.writeMetricForFlowNodeInstance(
       correlationId,
+      processInstanceId,
       processModelId,
       flowNodeInstanceId,
       flowNodeId,
       MetricMeasurementPoint.onFlowNodeResume,
-      processToken,
+      tokenPayload,
       timestamp,
     );
   }


### PR DESCRIPTION
## Changes

1. Add `processInstanceId` to written metrics
2. Add UseCase for retrieving metrics
3. Only store token payloads instead of the whole ProcessToken object
4. Remove duplicated `ProcessToken` type
5. Add author and maintainer info

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/367

PR: #3